### PR TITLE
Additional VM labels and fixed virtual disk backing issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build-simple:
 	go mod tidy
 	mkdir -p out
 	go build -o out/govc-exporter -gcflags CGO_ENABLED=0 ./cmd/exporter 
-	go build -o out/vcenter-object-exporter -gcflags CGO_ENABLED=0 ./cmd/vcenter-object-exporter
+	# go build -o out/vcenter-object-exporter -gcflags CGO_ENABLED=0 ./cmd/vcenter-object-exporter
 
 vendor:
 	go mod vendor

--- a/internal/collector/vc_vm_perf.go
+++ b/internal/collector/vc_vm_perf.go
@@ -19,7 +19,7 @@ type VMPerfCollector struct {
 }
 
 func NewVMPerfCollector(scraper *scraper.VCenterScraper, cConf config.CollectorConfig) *VMPerfCollector {
-	labels := []string{"uuid", "name", "template", "vm_id"}
+	labels := []string{"uuid", "name", "template", "vm_id", "pool", "datacenter", "cluster", "esx", "power_state"}
 	extraLabels := cConf.VMTagLabels
 	if len(extraLabels) != 0 {
 		labels = append(labels, extraLabels...)
@@ -60,7 +60,7 @@ func (c *VMPerfCollector) Collect(ch chan<- prometheus.Metric) {
 			extraLabelValues = append(extraLabelValues, objectTags.GetTag(tagCat))
 		}
 
-		labelValues := []string{vm.UUID, vm.Name, strconv.FormatBool(vm.Template), vm.Self.ID()}
+		labelValues := []string{vm.UUID, vm.Name, strconv.FormatBool(vm.Template), vm.Self.ID(), vm.ResourcePool, vm.Datacenter, vm.HostInfo.Cluster, vm.HostInfo.Host, vm.PowerState}
 		labelValues = append(labelValues, extraLabelValues...)
 
 		for metric := range c.scraper.MetricsDB.PopAllVmMetricsIter(ctx, vm.Self) {

--- a/internal/database/objects/virtual_machine.go
+++ b/internal/database/objects/virtual_machine.go
@@ -41,6 +41,7 @@ type VirtualMachine struct {
 	GuestToolsStatus     string  `json:"guest_tools_status" redis:"guest_tools_status"`
 	GuestToolsVersion    string  `json:"guest_tools_version" redis:"guest_tools_version"`
 	GuestID              string  `json:"guest_id" redis:"guest_id"`
+	GuestFullName        string  `json:"guest_full_name" redis:"guest_full_name"`
 
 	// Legacy metrics
 	DistributedCPUEntitlement    float64 `json:"distributed_cpu_entitlement" redis:"distributed_cpu_entitlement"`


### PR DESCRIPTION
When we were building our dashboards using these metrics we found that it was easier to have the datacenter, cluster, the host and the power state of the VM on the info label, instead of them being a separate metrics.

We also wanted to show the full name of the OS, so added that as well.

Lastly, we found that some of our VMs have a different backing. Added the fix, and a default to warn if a backing isn't defined so the exporter doesn't crash if this happens.